### PR TITLE
Changed default collation and removed charset.

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -139,8 +139,7 @@ func parseDuration(key string, q url.Values, def time.Duration) (time.Duration, 
 
 // DefaultDriverOpts are the default driver values if not provided in the DSN
 var DefaultDriverOpts = url.Values{
-	"collation":   {"utf8_unicode_ci"},
-	"charset":     {"utf8mb4"},
+	"collation":   {"utf8mb4_unicode_ci"},
 	"parseTime":   {"true"},
 	"autocommit":  {"true"},
 	"timeout":     {defaultConnectTimeout.String()},


### PR DESCRIPTION
From the driver docs.
"Usage of the charset parameter is discouraged because it issues additional queries to the server. Unless you need the fallback behavior, please use collation instead."
https://github.com/go-sql-driver/mysql

Switched collation from utf8_unicode_ci to utf8mb4_unicode_ci to compensate. utf8 is the alias to utf8mb3 and does not support 4 byte characters.

https://dev.mysql.com/doc/refman/5.5/en/charset-unicode.html
